### PR TITLE
Fix SoundTab selected index update loop

### DIFF
--- a/src/containers/sound-tab.jsx
+++ b/src/containers/sound-tab.jsx
@@ -73,9 +73,14 @@ class SoundTab extends React.Component {
 
         // If switching editing targets, reset the sound index
         if (prevProps.editingTarget !== editingTarget) {
-            this.setState({selectedSoundIndex: 0});
-        } else if (this.state.selectedSoundIndex > target.sounds.length - 1) {
-            this.setState({selectedSoundIndex: Math.max(target.sounds.length - 1, 0)});
+            if (this.state.selectedSoundIndex !== 0) {
+                this.setState({selectedSoundIndex: 0});
+            }
+        } else {
+            const maxSoundIndex = Math.max(target.sounds.length - 1, 0);
+            if (this.state.selectedSoundIndex > maxSoundIndex) {
+                this.setState({selectedSoundIndex: maxSoundIndex});
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent an infinite `setState` loop in `componentDidUpdate` of `src/containers/sound-tab.jsx` that caused "Maximum update depth exceeded" when the sounds list was empty or when unnecessary state updates were performed.

### Description
- Add guards so switching editing targets only calls `setState({selectedSoundIndex: 0})` when `selectedSoundIndex !== 0`, and compute `maxSoundIndex = Math.max(target.sounds.length - 1, 0)` to only clamp the index when `selectedSoundIndex > maxSoundIndex`.

### Testing
- Attempted `npx eslint src/containers/sound-tab.jsx` and `npm run test:lint` but both failed due to the environment using ESLint v9 without an `eslint.config.js`, so lint checks could not be completed; no unit/integration tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6ef3dcc48320984e5ef6cb91ec15)